### PR TITLE
feat: Add CI/CD workflows for Terraform and app deployment

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1,0 +1,64 @@
+# Managed by CICD Engineer Agent
+# Builds, tests, and deploys the Node.js Task Management API to the Azure
+# Web App provisioned by Terraform. Includes a post-deploy health check to
+# confirm the app is live and responding.
+name: Deploy App
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'app/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    name: Build, Test & Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install dependencies
+        working-directory: app
+        run: npm ci
+
+      # Run the full test suite — fail fast if any test breaks.
+      - name: Run tests
+        working-directory: app
+        run: npm test
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          package: ./app
+
+      # Wait for the app to start, then verify the /health endpoint returns 200.
+      - name: Health check
+        run: |
+          sleep 30
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            https://${{ secrets.AZURE_WEBAPP_NAME }}.azurewebsites.net/health)
+          if [ "$STATUS" != "200" ]; then
+            echo "Health check failed — status $STATUS"
+            exit 1
+          fi
+          echo "Live at https://${{ secrets.AZURE_WEBAPP_NAME }}.azurewebsites.net"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,61 @@
+# Managed by CICD Engineer Agent
+# Runs terraform apply automatically after infra changes are merged to main,
+# provisioning the real Azure resources defined in the infra/ directory.
+name: Terraform Apply
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/**'
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform Init
+        working-directory: infra
+        run: terraform init
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform Apply
+        working-directory: infra
+        run: terraform apply -auto-approve
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          TF_VAR_app_name: "devops-agent-demo"
+
+      # Display Terraform outputs (e.g. web_app_name, resource_group) for
+      # visibility in the Actions log after provisioning completes.
+      - name: Show Outputs
+        working-directory: infra
+        run: terraform output
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,74 @@
+# Managed by CICD Engineer Agent
+# Runs terraform plan on every PR that modifies infra/ and posts the plan
+# output as a PR comment so reviewers can see exactly what Azure resources
+# will be created or changed before approving.
+name: Terraform Plan
+
+on:
+  pull_request:
+    paths:
+      - 'infra/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  plan:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform Init
+        working-directory: infra
+        run: terraform init
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform Validate
+        working-directory: infra
+        run: terraform validate
+
+      - name: Terraform Plan
+        id: plan
+        working-directory: infra
+        run: terraform plan -no-color 2>&1 | tee plan_output.txt
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          TF_VAR_app_name: "devops-agent-demo"
+
+      # Posts the full plan output as a comment on the PR so reviewers
+      # can inspect the planned changes without running Terraform locally.
+      - name: Post Plan to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('infra/plan_output.txt', 'utf8');
+            const truncated = plan.length > 60000
+              ? plan.substring(0, 60000) + '\n... (truncated)'
+              : plan;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## 🔍 Terraform Plan\n\`\`\`\n${truncated}\n\`\`\`\n\n*Merge to apply these changes.*`
+            });


### PR DESCRIPTION
## CI/CD Pipelines — CICD Engineer Agent\n\nCloses #11\n\nThis PR adds three GitHub Actions workflow files that automate the full CI/CD lifecycle for the Task Management REST API project.\n\n### Workflows\n\n| Workflow | File | Trigger | Purpose |\n|----------|------|---------|---------|\n| **Terraform Plan** | `terraform-plan.yml` | PR modifying `infra/**` | Runs `terraform plan` and posts the output as a PR comment so reviewers can inspect changes before approving |\n| **Terraform Apply** | `terraform-apply.yml` | Push to `main` modifying `infra/**` | Runs `terraform apply -auto-approve` to provision Azure resources after merge |\n| **Deploy App** | `deploy-app.yml` | Push to `main` modifying `app/**` + manual dispatch | Installs deps, runs tests, deploys to Azure Web App, and runs a health check |\n\n### GitHub Secrets Required\n\n| Secret | Status |\n|--------|--------|\n| `AZURE_CLIENT_ID` | ✅ Already configured |\n| `AZURE_CLIENT_SECRET` | ✅ Already configured |\n| `AZURE_TENANT_ID` | ✅ Already configured |\n| `AZURE_SUBSCRIPTION_ID` | ✅ Already configured |\n| `AZURE_WEBAPP_NAME` | ⏳ Will be added after Terraform apply (Step 3) |\n\n### What happens after merge\n\n1. **Infra PRs** — `terraform-plan.yml` runs automatically and posts the plan as a comment\n2. **Infra merges to main** — `terraform-apply.yml` provisions Azure resources\n3. **App changes merged to main** — `deploy-app.yml` builds, tests, and deploys the Node.js app\n4. Manual deploys are also supported via `workflow_dispatch` on `deploy-app.yml`\n\n### Key design decisions\n- All workflows use pinned action versions (`@v4`, `@v3`, `@v2`)\n- Tests run before deployment — pipeline fails fast if tests break\n- `npm ci` used instead of `npm install` for reproducible builds\n- `TF_VAR_app_name` set to `devops-agent-demo` in Terraform workflows\n- Post-deploy health check verifies `/health` returns HTTP 200\n- Plan output truncated at 60k chars to stay within GitHub comment limits\n