### PR TITLE
ci: add Terraform and app deploy pipelines (CICD Engineer Agent)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1,0 +1,51 @@
+# Managed by CICD Engineer Agent
+name: Deploy App
+
+on:
+  push:
+    branches: [demo-test]
+    paths:
+      - 'app/**'
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Run tests
+        working-directory: app
+        run: npm test
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}"}'
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          package: ./app
+
+      - name: Health check
+        run: |
+          sleep 30
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            https://${{ secrets.AZURE_WEBAPP_NAME }}.azurewebsites.net/health)
+          if [ "$STATUS" != "200" ]; then
+            echo "Health check failed — status $STATUS"
+            exit 1
+          fi
+          echo "✅ Live at https://${{ secrets.AZURE_WEBAPP_NAME }}.azurewebsites.net"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,68 @@
+# Managed by CICD Engineer Agent
+name: Terraform Apply
+
+on:
+  push:
+    branches: [demo-test]
+    paths:
+      - 'infra/**'
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      secrets: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}"}'
+
+      - name: Terraform Init
+        working-directory: infra
+        run: terraform init
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform Apply
+        working-directory: infra
+        run: terraform apply -auto-approve
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Set AZURE_WEBAPP_NAME secret
+        working-directory: infra
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          WEBAPP_NAME=$(terraform output -raw web_app_name)
+          echo "Setting AZURE_WEBAPP_NAME secret to: $WEBAPP_NAME"
+          gh secret set AZURE_WEBAPP_NAME --body "$WEBAPP_NAME" --repo ${{ github.repository }}
+          echo "✅ AZURE_WEBAPP_NAME secret set to: $WEBAPP_NAME"
+
+      - name: Show Outputs
+        working-directory: infra
+        run: terraform output
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,57 @@
+# Managed by CICD Engineer Agent
+name: Terraform Plan
+
+on:
+  pull_request:
+    paths:
+      - 'infra/**'
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}"}'
+
+      - name: Terraform Init
+        working-directory: infra
+        run: terraform init
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform Validate
+        working-directory: infra
+        run: terraform validate
+
+      - name: Terraform Plan
+        id: plan
+        working-directory: infra
+        run: terraform plan -no-color 2>&1 | tee plan_output.txt
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Post Plan to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('infra/plan_output.txt', 'utf8');
+            const truncated = plan.length > 60000 ? plan.substring(0, 60000) + '\n... (truncated)' : plan;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## 🔍 Terraform Plan\n\`\`\`\n${truncated}\n\`\`\`\n\n*Approve this PR to apply these changes.*`
+            })


### PR DESCRIPTION
## Summary\n\nThree GitHub Actions workflows for the full DevOps pipeline.\n\n## Workflows Created\n\n| File | Trigger | Purpose |\n|------|---------|--------|\n| `terraform-plan.yml` | PR on `infra/**` | Runs `terraform init`, `validate`, `plan` — posts plan output as PR comment |\n| `terraform-apply.yml` | Push to `demo-test` on `infra/**` | Provisions Azure resources via `terraform apply`, auto-sets `AZURE_WEBAPP_NAME` secret |\n| `deploy-app.yml` | Push to `demo-test` on `app/**` + `workflow_dispatch` | Installs deps (`npm ci`), runs tests, deploys Node.js app to Azure Web App, health check |\n\n## Pipeline Flow\n\n```\nPR (infra/**) → terraform-plan.yml → posts plan as PR comment\n        ↓ (merge to demo-test)\nPush (infra/**) → terraform-apply.yml → provisions Azure → sets AZURE_WEBAPP_NAME secret\n        ↓\nPush (app/**) or manual → deploy-app.yml → npm ci → test → deploy → health check\n```\n\n## Secrets Required\n\n| Secret | Status |\n|--------|--------|\n| `AZURE_CLIENT_ID` | ✅ Configured |\n| `AZURE_CLIENT_SECRET` | ✅ Configured |\n| `AZURE_TENANT_ID` | ✅ Configured |\n| `AZURE_SUBSCRIPTION_ID` | ✅ Configured |\n| `AZURE_WEBAPP_NAME` | ⏳ Auto-set by `terraform-apply.yml` after infra provisioning |\n\n## Key Design Decisions\n\n- **Azure Login** uses `creds` JSON format (not OIDC) — no federated credentials needed\n- **`terraform_wrapper: false`** on apply workflow for clean output parsing\n- **`permissions: secrets: write`** on apply workflow to set `AZURE_WEBAPP_NAME` automatically\n- **Health check** in deploy workflow verifies the app is live after deployment\n- All actions pinned: `checkout@v4`, `setup-node@v4`, `setup-terraform@v3`, `azure/login@v2`, `webapps-deploy@v3`, `github-script@v7`\n\nCloses #45