### PR TITLE
test: add basic API tests to fix deploy-app.yml failure

### DIFF
--- a/app/__tests__/api.test.js
+++ b/app/__tests__/api.test.js
@@ -1,0 +1,57 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('GET /health', () => {
+  it('should return 200 with status ok', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.timestamp).toBeDefined();
+  });
+});
+
+describe('Task CRUD', () => {
+  let taskId;
+
+  it('POST /tasks — should create a task', async () => {
+    const res = await request(app)
+      .post('/tasks')
+      .send({ title: 'Test task', description: 'A test', status: 'todo' });
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBeDefined();
+    expect(res.body.title).toBe('Test task');
+    taskId = res.body.id;
+  });
+
+  it('GET /tasks — should list tasks', async () => {
+    const res = await request(app).get('/tasks');
+    expect(res.status).toBe(200);
+    expect(res.body.tasks).toBeInstanceOf(Array);
+    expect(res.body.tasks.length).toBeGreaterThan(0);
+  });
+
+  it('GET /tasks/:id — should return a task', async () => {
+    const res = await request(app).get(`/tasks/${taskId}`);
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(taskId);
+  });
+
+  it('PUT /tasks/:id — should update a task', async () => {
+    const res = await request(app)
+      .put(`/tasks/${taskId}`)
+      .send({ title: 'Updated task', status: 'done' });
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe('Updated task');
+    expect(res.body.status).toBe('done');
+  });
+
+  it('DELETE /tasks/:id — should delete a task', async () => {
+    const res = await request(app).delete(`/tasks/${taskId}`);
+    expect(res.status).toBe(204);
+  });
+
+  it('GET /tasks/:id — should return 404 after delete', async () => {
+    const res = await request(app).get(`/tasks/${taskId}`);
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

The `deploy-app.yml` workflow failed at the **Run tests** step because no test files existed. Jest exits with failure code when it finds zero tests.

## Root Cause

The Software Developer agent created `package.json` with `"test": "jest --coverage"` and `supertest` as a dev dependency, but no test files were created under `app/`.

## Fix

Added `app/__tests__/api.test.js` with supertest-based tests covering:
- `GET /health` — health check returns 200 with status ok
- `POST /tasks` — creates a task (201)
- `GET /tasks` — lists tasks (200)
- `GET /tasks/:id` — gets a specific task (200)
- `PUT /tasks/:id` — updates a task (200)
- `DELETE /tasks/:id` — deletes a task (204)
- `GET /tasks/:id` after delete — returns 404

## Impact

Once merged, re-triggering `deploy-app.yml` should pass the test step and proceed to deployment.